### PR TITLE
fix pdf output by switching to absolute urls

### DIFF
--- a/resume.template
+++ b/resume.template
@@ -6,8 +6,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Resume of {{basics.name}}</title>
-    <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
     <style type="text/css">
     {{{css}}}
     </style>


### PR DESCRIPTION
There is a bug with the PDF output where assets with protocol-independent URLS such as `//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.2.0/css/bootstrap.min.css` are not loaded https://github.com/jsonresume/resume-cli/issues/69
A workaround is to use the full URL.

For example, compare:
<http://registry.jsonresume.org/linuxbozo.pdf>
to:
<http://registry.jsonresume.org/linuxbozo.pdf?theme=kendall-fix>

