### PR TITLE
added default behavior for unknown networks

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,6 +118,8 @@ function render(resumeObject) {
             case "rss":
                 p.iconClass = "fa fa-rss-square";
                 break;
+            default:
+                p.iconClass = "fa fa-" + p.network.toLowerCase() + "-square";
         }
 
         if (p.url) {


### PR DESCRIPTION
If a social media account cannot be resolved by the theme, try to load fontawesome icon anyway.

This could also solve the need of hardcode each new network icon as long as the spelling is matching with the icon-name.

see LinuxBozo/jsonresume-theme-kendall#9