### PR TITLE
Add support for Certificates

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,6 +205,17 @@ function render(resumeObject) {
         }
     }
 
+    if (resumeObject.certificates && resumeObject.certificates.length) {
+        if (resumeObject.certificates[0].name) {
+            resumeObject.certificatesBool = true;
+            _.each(resumeObject.certificates, function(a){
+                a.year = (a.date || "").substr(0,4);
+                a.day = (a.date || "").substr(8,2);
+                a.month = getMonth(a.date || "");
+            });
+        }
+    }
+
     if (resumeObject.publications && resumeObject.publications.length) {
         if (resumeObject.publications[0].name) {
             resumeObject.publicationsBool = true;

--- a/print.css
+++ b/print.css
@@ -18,6 +18,7 @@ a[href]:after {
 blockquote,
 #education,
 #awards,
+#certificates,
 .contact-item,
 .publication,
 .skills,
@@ -46,11 +47,13 @@ blockquote,
   margin-bottom: -20px;
 }
 #awards:before,
+#certificates:before,
 #education:before {
   background: none;
 }
 
 #awards .description,
+#certificates .description,
 #education .description,
 .job .details {
   border: 1px solid #eee;

--- a/resume.template
+++ b/resume.template
@@ -95,7 +95,7 @@
           {{#awardsBool}}
           <!-- AWARDS -->
           <div class="box">
-            <h2><i class="fas fa-certificate ico"></i> Awards</h2>
+            <h2><i class="fas fa-awards ico"></i> Awards</h2>
             <ul id="awards" class="clearfix">
               {{#awards}}
               <li>
@@ -110,6 +110,28 @@
             </ul>
           </div>
           {{/awardsBool}}
+          {{#certificatesBool}}
+          <!-- CERTIFICATES -->
+          <div class="box">
+            <h2><i class="fas fa-certificate ico"></i> Certificates</h2>
+            <ul id="certificates" class="clearfix">
+              {{#certificates}}
+              <li>
+                <div class="year pull-left">{{month}} {{year}}</div>
+                <div class="description pull-right">
+                  <h3>{{issuer}}</h3>
+                  <p><i class="fas fa-book-open ico"></i> {{name}}</p>
+                  {{#url}}
+                    <div class="address">
+                      <a href="{{url}}" target= "_blank"><i class="fas fa-globe ico"></i> {{url}}</a>
+                    </div>
+                  {{/url}}
+                </div>
+              </li>
+              {{/certificates}}
+            </ul>
+          </div>
+          {{/certificatesBool}}
           {{#volunteerBool}}
           <!-- VOLUNTEER -->
           <div class="box">

--- a/resume.template
+++ b/resume.template
@@ -95,7 +95,7 @@
           {{#awardsBool}}
           <!-- AWARDS -->
           <div class="box">
-            <h2><i class="fas fa-awards ico"></i> Awards</h2>
+            <h2><i class="fas fa-award ico"></i> Awards</h2>
             <ul id="awards" class="clearfix">
               {{#awards}}
               <li>

--- a/style.css
+++ b/style.css
@@ -80,7 +80,8 @@ blockquote {
 }
 
 #awards,
-#education{
+#certificates,
+#education {
   margin-top: 20px;
   margin-bottom: 0;
   position: relative;
@@ -88,6 +89,7 @@ blockquote {
   list-style: none;
 }
 #awards:before,
+#certificates:before,
 #education:before {
   width: 5px;
   height: 100%;
@@ -106,6 +108,7 @@ blockquote {
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#ffffff',GradientType=0 );
 }
 #awards li,
+#certificates li,
 #education li{
   width: 100%;
   z-index: 2;
@@ -113,6 +116,7 @@ blockquote {
   float: left;
 }
 #awards .year,
+#certificates .year,
 #education .year{
   width: 14%;
   background: #fff;
@@ -121,6 +125,7 @@ blockquote {
   display: inline-block;
 }
 #awards .description,
+#certificates .description,
 #education .description{
   width: 83%;
   display: inline-block;
@@ -132,6 +137,7 @@ blockquote {
   border-right: 1px solid #ccc;
 }
 #awards .description:after,
+#certificates .description:after,
 #education .description:after {
   content: '';
   position: absolute;
@@ -146,6 +152,7 @@ blockquote {
   pointer-events: none;
 }
 #awards .description h3,
+#certificates .description h3,
 #education .description h3{
   font-size: 1.2em;
   margin: 0;
@@ -153,6 +160,7 @@ blockquote {
   font-weight: 700;
 }
 #awards .description p,
+#certificates .description p,
 #education .description p{
   margin-top: 5px;
   padding: 0;


### PR DESCRIPTION
Hi,

I saw the template does not currently have support for certificates and there is an open issue (#35) requesting it.
I thought I'd take a shot at adding support for it. I used the awards section as a template to work off.

I also changed icons for the awards section header to an award ribbon.
Also changed the "trophy" icon under the certificates section to an open book.
I changed them to create some visual distinction between awards and certificates, I'm not too fussed if you'd prefer to keep the previous style rather.

![image](https://user-images.githubusercontent.com/5462748/216179620-b7d84ddf-fc4e-494c-85fd-309d6346d64e.png)


