### PR TITLE
feat: change font-awesome icon lib by fork-awesome

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,46 +54,46 @@ function render(resumeObject) {
             // special cases
             case "google-plus":
             case "googleplus":
-                p.iconClass = "fab fa-google-plus";
+                p.iconClass = "fa fa-google-plus";
                 break;
             case "flickr":
             case "flicker":
-                p.iconClass = "fab fa-flickr";
+                p.iconClass = "fa fa-flickr";
                 break;
             case "dribbble":
             case "dribble":
-                p.iconClass = "fab fa-dribbble";
+                p.iconClass = "fa fa-dribbble";
                 break;
             case "codepen":
-                p.iconClass = "fab fa-codepen";
+                p.iconClass = "fa fa-codepen";
                 break;
             case "soundcloud":
-                p.iconClass = "fab fa-soundcloud";
+                p.iconClass = "fa fa-soundcloud";
                 break;
             case "reddit":
-                p.iconClass = "fab fa-reddit";
+                p.iconClass = "fa fa-reddit";
                 break;
             case "tumblr":
             case "tumbler":
-                p.iconClass = "fab fa-tumblr";
+                p.iconClass = "fa fa-tumblr";
                 break;
             case "stack-overflow":
             case "stackoverflow":
-                p.iconClass = "fab fa-stack-overflow";
+                p.iconClass = "fa fa-stack-overflow";
                 break;
             case "blog":
             case "rss":
-                p.iconClass = "fas fa-rss";
+                p.iconClass = "fa fa-rss";
                 break;
             case "gitlab":
-                p.iconClass = "fab fa-gitlab";
+                p.iconClass = "fa fa-gitlab";
                 break;
             case "keybase":
-                p.iconClass = "fas fa-key";
+                p.iconClass = "fa fa-key";
                 break;
             default:
                 // try to automatically select the icon based on the name
-                p.iconClass = "fab fa-" + p.network.toLowerCase();
+                p.iconClass = "fa fa-" + p.network.toLowerCase();
         }
 
         if (p.url) {

--- a/resume.template
+++ b/resume.template
@@ -9,7 +9,7 @@
     <!-- <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet"> -->
     <!-- <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"> -->
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.14.0/css/all.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fork-awesome@1.2.0/css/fork-awesome.min.css" integrity="sha256-XoaMnoYC5TH6/+ihMEnospgm0J1PM/nioxbOUdnM8HY=" crossorigin="anonymous">
     <style type="text/css">
     {{{css}}}
     </style>
@@ -39,14 +39,14 @@
           {{#basics.summary}}
           <!-- ABOUT ME -->
           <div class="box">
-            <h2><i class="fas fa-user ico"></i> About</h2>
+            <h2><i class="fa fa-user ico"></i> About</h2>
             <p>{{{basics.summary}}}</p>
           </div>
           {{/basics.summary}}
           {{#workBool}}
           <!-- WORK EXPERIENCE -->
           <div class="box">
-            <h2><i class= "fas fa-suitcase ico"></i> Work Experience</h2>
+            <h2><i class= "fa fa-suitcase ico"></i> Work Experience</h2>
             {{#work}}
               <div class="job clearfix">
                 <div class="row">
@@ -66,7 +66,7 @@
                     {{/description}}
                     {{#url}}
                     <div class="address">
-                      <a href="{{url}}" target= "_blank"><i class="fas fa-globe ico"></i> {{url}}</a>
+                      <a href="{{url}}" target= "_blank"><i class="fa fa-globe ico"></i> {{url}}</a>
                     </div>
                     {{/url}}
                     <div class="year">{{startDateMonth}}{{startDateYear}} – {{endDateMonth}}{{endDateYear}}</div>
@@ -95,14 +95,14 @@
           {{#awardsBool}}
           <!-- AWARDS -->
           <div class="box">
-            <h2><i class="fas fa-certificate ico"></i> Awards</h2>
+            <h2><i class="fa fa-certificate ico"></i> Awards</h2>
             <ul id="awards" class="clearfix">
               {{#awards}}
               <li>
                 <div class="year pull-left">{{month}} {{year}}</div>
                 <div class="description pull-right">
                   <h3>{{awarder}}</h3>
-                  <p><i class="fas fa-trophy ico"></i> {{title}}</p>
+                  <p><i class="fa fa-trophy ico"></i> {{title}}</p>
                   <p>{{{summary}}}</p>
                 </div>
               </li>
@@ -113,7 +113,7 @@
           {{#volunteerBool}}
           <!-- VOLUNTEER -->
           <div class="box">
-            <h2><i class= "fas fa-users ico"></i> Volunteer</h2>
+            <h2><i class= "fa fa-users ico"></i> Volunteer</h2>
             {{#volunteer}}
               <div class="job clearfix">
                 <div class="row">
@@ -121,7 +121,7 @@
                     <div class="where">{{organization}}</div>
                     {{#url}}
                     <div class="address">
-                      <a href="{{url}}" target= "_blank"><i class="fas fa-globe ico"></i> {{url}}</a>
+                      <a href="{{url}}" target= "_blank"><i class="fa fa-globe ico"></i> {{url}}</a>
                     </div>
                     {{/url}}
                     <div class="year">{{startDateMonth}}{{startDateYear}} – {{endDateMonth}}{{endDateYear}}</div>
@@ -150,7 +150,7 @@
           {{#projectsBool}}
           <!-- PROJECTS -->
           <div class="box">
-            <h2><i class= "fas fa-code-branch ico"></i> Projects</h2>
+            <h2><i class= "fa fa-code-branch ico"></i> Projects</h2>
             <ul class="list-group">
               {{#projects}}
               <li class="list-group-item">
@@ -164,29 +164,29 @@
         <div class="col-xs-12 col-sm-5">
           <!-- CONTACT -->
           <div class="box clearfix">
-            <h2><i class="fas fa-bullseye ico"></i> Contact</h2>
+            <h2><i class="fa fa-bullseye ico"></i> Contact</h2>
             {{#basics.location}}
             <div class="contact-item">
-              <div class="icon pull-left text-center"><span class="fas fa-map-marker fa-fw"></span></div>
+              <div class="icon pull-left text-center"><span class="fa fa-map-marker fa-fw"></span></div>
               {{#basics.location.address}}<div class="title pull-right">{{basics.location.address}}</div>{{/basics.location.address}}
               <div class="title {{^basics.location.address}}only {{/basics.location.address}} pull-right">{{basics.location.city}}{{#basics.location.region}}, {{basics.location.region}}{{/basics.location.region}}{{#basics.location.postalCode}} {{basics.location.postalCode}}{{/basics.location.postalCode}}{{#basics.location.countryCode}} {{basics.location.countryCode}}{{/basics.location.countryCode}}</div>
             </div>
             {{/basics.location}}
             {{#basics.phone}}
             <div class="contact-item">
-              <div class="icon pull-left text-center"><span class="fas fa-phone fa-fw"></span></div>
+              <div class="icon pull-left text-center"><span class="fa fa-phone fa-fw"></span></div>
               <div class="title only pull-right">{{basics.phone}}</div>
             </div>
             {{/basics.phone}}
             {{#basics.email}}
             <div class="contact-item">
-              <div class="icon pull-left text-center"><span class="fas fa-envelope fa-fw"></span></div>
+              <div class="icon pull-left text-center"><span class="fa fa-envelope fa-fw"></span></div>
               <div class="title only pull-right"><a href="mailto:{{basics.email}}" target="_blank">{{basics.email}}</a></div>
             </div>
             {{/basics.email}}
             {{#basics.url}}
             <div class="contact-item">
-              <div class="icon pull-left text-center"><span class="fas fa-globe fa-fw"></span></div>
+              <div class="icon pull-left text-center"><span class="fa fa-globe fa-fw"></span></div>
               <div class="title only pull-right"><a href="{{basics.url}}" target="_blank">{{basics.url}}</a></div>
             </div>
             {{/basics.url}}
@@ -201,7 +201,7 @@
           {{#educationBool}}
           <!-- EDUCATION -->
           <div class="box">
-            <h2><i class="fas fa-university ico"></i> Education</h2>
+            <h2><i class="fa fa-university ico"></i> Education</h2>
             <ul id="education" class="clearfix">
               {{#education}}
               <li>
@@ -211,10 +211,10 @@
                   <div class="where">{{organization}}</div>
                   {{#url}}
                   <div class="address">
-                    <a href="{{url}}" target= "_blank"><i class="fas fa-globe ico"></i> {{url}}</a>
+                    <a href="{{url}}" target= "_blank"><i class="fa fa-globe ico"></i> {{url}}</a>
                   </div>
                   {{/url}}
-                  {{#studyType}}<p><i class= "fas fa-graduation-cap ico"></i> {{studyType}}</p>{{/studyType}}
+                  {{#studyType}}<p><i class= "fa fa-graduation-cap ico"></i> {{studyType}}</p>{{/studyType}}
                   <p>{{area}}</p>
                   {{#score}}
                   <p>
@@ -238,7 +238,7 @@
           {{#skillsBool}}
           <!-- SKILLS -->
           <div class="box">
-            <h2><i class="fas fa-tasks ico"></i> Skills</h2>
+            <h2><i class="fa fa-tasks ico"></i> Skills</h2>
             {{#skills}}
             <div class="skills clearfix">
               <div class="item-skills">
@@ -257,7 +257,7 @@
           {{#publicationsBool}}
           <!-- PUBLICATIONS -->
           <div class="box">
-            <h2><i class="fas fa-book ico"></i> Publications</h2>
+            <h2><i class="fa fa-book ico"></i> Publications</h2>
             {{#publications}}
             <div class="publication panel panel-default">
               <div class="panel-heading">
@@ -265,12 +265,12 @@
               </div>
               <div class="panel-body">
                 {{#publisher}}
-                <div class="publisher"><i class= "fas fa-bookmark ico"></i> {{publisher}}</div>
+                <div class="publisher"><i class= "fa fa-bookmark ico"></i> {{publisher}}</div>
                 {{/publisher}}
                 <div class="year">{{day}} {{month}} {{year}}</div>
                 {{#url}}
                 <div class="address">
-                  <a href="{{url}}" target= "_blank"><i class="fas fa-globe ico"></i> {{url}}</a>
+                  <a href="{{url}}" target= "_blank"><i class="fa fa-globe ico"></i> {{url}}</a>
                 </div>
                 {{/url}}
                 {{#summary}}
@@ -284,7 +284,7 @@
           {{#languagesBool}}
           <!-- LANGUAGES -->
           <div class="box">
-            <h2><i class="fas fa-language ico"></i> Languages</h2>
+            <h2><i class="fa fa-language ico"></i> Languages</h2>
             <ul class="list-group">
               {{#languages}}
               <li class=" list-group-item">{{language}}<span class="skill badge pull-right">{{fluency}}</span></li>
@@ -295,7 +295,7 @@
           {{#interestsBool}}
           <!-- HOBBIES -->
           <div class="box">
-            <h2><i class="fas fa-heart ico"></i> Interests</h2>
+            <h2><i class="fa fa-heart ico"></i> Interests</h2>
             {{#interests}}
             <div class="interests clearfix">
               <div class="item-interests">
@@ -312,7 +312,7 @@
           {{/interestsBool}}
           {{#referencesBool}}
           <div class="box">
-            <h2><i class= "fas fa-check-square ico"></i> References</h2>
+            <h2><i class= "fa fa-check-square ico"></i> References</h2>
             {{#references}}
             <blockquote>
               <div>{{{reference}}}</div>


### PR DESCRIPTION
When I wanted to add a matrix.org link to my list of profiles, I saw that font-awesome did not have this icon.
The fork of this project, [fork-awesome](https://github.com/ForkAwesome/Fork-Awesome), has this icon and allows PRs to add new icons.
So I created a branch to change one for the other.

However, I'm not sure if another icon than the matrix.org one is missing in font-awesome. I'll let you close this PR if you don't think this change is appropriate.

Thanks for your work