### PR TITLE
Add certificates section rendering

### DIFF
--- a/index.js
+++ b/index.js
@@ -216,6 +216,17 @@ function render(resumeObject) {
         }
     }
 
+    if (resumeObject.certificates && resumeObject.certificates.length) {
+        if (resumeObject.certificates[0].name) {
+            resumeObject.certificatesBool = true;
+            _.each(resumeObject.certificates, function(c){
+                c.year = (c.date || "").substr(0,4);
+                c.day = (c.date || "").substr(8,2);
+                c.month = getMonth(c.date || "");
+            });
+        }
+    }
+
     if (resumeObject.skills && resumeObject.skills.length) {
         if (resumeObject.skills[0].name) {
             resumeObject.skillsBool = true;

--- a/resume.template
+++ b/resume.template
@@ -281,6 +281,30 @@
             {{/publications}}
           </div>
           {{/publicationsBool}}
+          {{#certificatesBool}}
+          <!-- CERTIFICATES -->
+          <div class="box">
+            <h2><i class="fas fa-award ico"></i> Certificates</h2>
+            {{#certificates}}
+            <div class="publication panel panel-default">
+              <div class="panel-heading">
+                <div class="name panel-title">{{name}}</div>
+              </div>
+              <div class="panel-body">
+                {{#issuer}}
+                <div class="publisher"><i class= "fas fa-building ico"></i> {{issuer}}</div>
+                {{/issuer}}
+                <div class="year">{{day}} {{month}} {{year}}</div>
+                {{#url}}
+                <div class="address">
+                  <a href="{{url}}" target= "_blank"><i class="fas fa-globe ico"></i> {{url}}</a>
+                </div>
+                {{/url}}
+              </div>
+            </div>
+            {{/certificates}}
+          </div>
+          {{/certificatesBool}}
           {{#languagesBool}}
           <!-- LANGUAGES -->
           <div class="box">


### PR DESCRIPTION
Adds rendering for the `certificates` section, which was the only JSON Resume schema section the template didn't output. It follows the existing publications panel idiom (name / issuer / date / url) and the `*Bool` flag pattern in `index.js`, so it slots in with no style changes elsewhere.

Verified by rendering a full resume fixture (every schema section populated, including two certificates — one with a URL, one without): the section now appears and all other sections are unaffected.

Context: this came out of a section-coverage QA sweep across the registered JSON Resume themes (jsonresume/jsonresume.org#360), where kendall showed as missing `certificates`. There's an older PR (#42) that also touched certificates but bundled unrelated changes; this one is intentionally minimal and certificates-only. Happy to adjust anything to match your preferences.

— AI (on behalf of the JSON Resume org theme QA)
